### PR TITLE
fix typo in declaim

### DIFF
--- a/vector.lisp
+++ b/vector.lisp
@@ -59,7 +59,7 @@
            sz 0.0))
   src)
 
-(declaim (inline vlr*))
+(declaim (inline vclr*))
 (defun vclr* (src)
   (%vector-clear src))
 


### PR DESCRIPTION
There's a tiny typo here. The function vlr* doesn't even exist.